### PR TITLE
Use environment backend URL

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -16,4 +16,22 @@ npm start
 - Article (статья)
 
 ## Хранилище
-- AsyncStorage: bias-вектор, отложенные реакции 
+- AsyncStorage: bias-вектор, отложенные реакции
+
+## Настройка URL сервера
+
+Адрес backend задаётся переменной окружения `EXPO_PUBLIC_API_BASE_URL`. Если переменная не указана, используется `http://localhost:3001`.
+
+### Пример для разработки
+
+```bash
+EXPO_PUBLIC_API_BASE_URL=https://your-dev-url.ngrok.app npm start
+```
+
+### Пример для продакшена
+
+При сборке укажите продакшен URL:
+
+```bash
+EXPO_PUBLIC_API_BASE_URL=https://api.example.com expo build
+```

--- a/app/config.js
+++ b/app/config.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL || 'http://localhost:3001';

--- a/app/screens/ArticleScreen.js
+++ b/app/screens/ArticleScreen.js
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { 
-  View, 
-  Text, 
-  ScrollView, 
-  TouchableOpacity, 
-  StyleSheet, 
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  StyleSheet,
   SafeAreaView,
   ActivityIndicator,
   Alert,
@@ -13,18 +13,7 @@ import {
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
-
-// Определяем URL в зависимости от платформы
-const getApiBaseUrl = () => {
-  if (__DEV__) {
-    // Используйте ваш ngrok URL или туннель
-    return 'https://ayv0dz-2a01-620-1c4b-a400-2c-e180-9897-8f1d.ru.tuna.am'; // ЗАМЕНИТЕ НА ВАШ ТЕКУЩИЙ ТУННЕЛЬ URL
-  } else {
-    return 'http://193.23.219.62:3001';
-  }
-};
-
-const API_BASE_URL = getApiBaseUrl();
+import { API_BASE_URL } from '../config';
 
 export default function ArticleScreen({ route, navigation }) {
   const { url } = route.params;

--- a/app/screens/FeedScreen.js
+++ b/app/screens/FeedScreen.js
@@ -1,11 +1,11 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { 
-  View, 
-  Text, 
-  FlatList, 
-  RefreshControl, 
-  TouchableOpacity, 
-  StyleSheet, 
+import {
+  View,
+  Text,
+  FlatList,
+  RefreshControl,
+  TouchableOpacity,
+  StyleSheet,
   SafeAreaView,
   Image,
   Alert,
@@ -13,19 +13,7 @@ import {
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
-
-// Определяем URL в зависимости от платформы
-const getApiBaseUrl = () => {
-  if (__DEV__) {
-    // Используйте ваш ngrok URL или туннель URL
-    return 'https://ayv0dz-2a01-620-1c4b-a400-2c-e180-9897-8f1d.ru.tuna.am'; // ЗАМЕНИТЕ НА ВАШ ТЕКУЩИЙ ТУННЕЛЬ URL
-  } else {
-    // В продакшене
-    return 'http://193.23.219.62:3001';
-  }
-};
-
-const API_BASE_URL = getApiBaseUrl();
+import { API_BASE_URL } from '../config';
 
 export default function FeedScreen({ navigation }) {
   const [cards, setCards] = useState([]);


### PR DESCRIPTION
## Summary
- add config file with `API_BASE_URL`
- reference the config constant in screens
- document how to configure backend URL

## Testing
- `npm -v`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685a0dd120c8832a8b185c8e7b79d973