### PR TITLE
Add Mercury article parsing

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "redis": "^4.6.7",
     "pg": "^8.11.5",
     "dotenv": "^16.4.5",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "@postlight/mercury-parser": "^2.2.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.0"

--- a/backend/src/article.js
+++ b/backend/src/article.js
@@ -1,14 +1,31 @@
 import axios from 'axios';
+import Mercury from '@postlight/mercury-parser';
 
-// TODO: заменить на Mercury/Readability
+// Парсит статью по URL и возвращает основные поля
 export async function parseArticle(url) {
-  // Заглушка: просто возвращаем title и htmlContent
-  const { data } = await axios.get(url);
-  return {
-    title: url,
-    author: '',
-    publishedAt: '',
-    htmlContent: data,
-    readingTimeSec: 120
-  };
-} 
+  let html;
+
+  try {
+    const res = await axios.get(url, { responseType: 'text' });
+    html = res.data;
+  } catch (err) {
+    // URL недоступен или произошла сетевая ошибка
+    throw new Error(`URL unreachable: ${err.message}`);
+  }
+
+  try {
+    const parsed = await Mercury.parse(url, { html });
+    return {
+      title: parsed.title || url,
+      author: parsed.author || '',
+      publishedAt: parsed.date_published || '',
+      htmlContent: parsed.content || '',
+      readingTimeSec: parsed.word_count
+        ? Math.ceil((parsed.word_count / 200) * 60)
+        : 0
+    };
+  } catch (err) {
+    throw new Error(`Failed to parse article: ${err.message}`);
+  }
+}
+


### PR DESCRIPTION
## Summary
- parse article HTML with `@postlight/mercury-parser`
- include author, publish date and sanitized HTML
- detect unreachable URLs
- include new dependency in backend package.json

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685a0de9c9bc832a927afe7a5d0d2039